### PR TITLE
Validate login email with Google authentication

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { signIn } from "next-auth/react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      await signIn("google", {
+        callbackUrl: "/",
+        // Pass login_hint so Google pre-fills the email
+        login_hint: email || undefined,
+      });
+    } catch (err) {
+      setError("Unable to start sign-in. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex w-full items-center justify-center py-10">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Sign in</CardTitle>
+          <CardDescription>
+            Use your Google account. Enter your email to speed things up.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="you@example.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                autoComplete="email"
+              />
+            </div>
+            {error ? (
+              <p className="text-sm text-destructive">{error}</p>
+            ) : null}
+            <Button type="submit" className="w-full" disabled={isSubmitting}>
+              {isSubmitting ? "Redirecting..." : "Continue with Google"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/src/components/user-nav.tsx
+++ b/src/components/user-nav.tsx
@@ -25,9 +25,11 @@ export function UserNav() {
 
   if (status === 'unauthenticated' || !session) {
     return (
-      <Button onClick={() => signIn('google')}>
-        Sign In with Google
-      </Button>
+      <Link href="/login">
+        <Button>
+          Sign In
+        </Button>
+      </Link>
     );
   }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,7 +7,49 @@ export const authOptions: NextAuthOptions = {
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      authorization: {
+        params: {
+          // Allow login_hint from our custom login page to prefill Google prompt
+          // NextAuth will merge incoming params from signIn() call
+        },
+      },
     }),
   ],
   secret: process.env.NEXTAUTH_SECRET,
+  pages: {
+    signIn: '/login',
+  },
+  callbacks: {
+    async signIn({ account, profile }) {
+      // Only allow Google sign-in
+      if (account?.provider !== 'google') return false;
+
+      // Ensure Google verified the email
+      const isVerified = (profile as any)?.email_verified;
+      const email = (profile as any)?.email as string | undefined;
+      if (!email || !isVerified) return false;
+
+      // Optional allow-listing via env vars
+      const allowedEmails = (process.env.ALLOWED_EMAILS || '')
+        .split(',')
+        .map((e) => e.trim().toLowerCase())
+        .filter(Boolean);
+      const allowedDomains = (process.env.ALLOWED_EMAIL_DOMAINS || '')
+        .split(',')
+        .map((d) => d.trim().toLowerCase())
+        .filter(Boolean);
+
+      if (allowedEmails.length === 0 && allowedDomains.length === 0) {
+        return true;
+      }
+
+      const emailLower = email.toLowerCase();
+      if (allowedEmails.includes(emailLower)) return true;
+
+      const domain = emailLower.split('@')[1];
+      if (domain && allowedDomains.includes(domain)) return true;
+
+      return false;
+    },
+  },
 };


### PR DESCRIPTION
Implement a custom login page and add email/domain allow-listing for Google authentication.

This change introduces a dedicated login page where users can input their email, which is then used as a `login_hint` for Google sign-in. It also adds a NextAuth callback to restrict access to specific emails or domains defined by `ALLOWED_EMAILS` and `ALLOWED_EMAIL_DOMAINS` environment variables, fulfilling the requirement to "check" the email during authentication.

---
<a href="https://cursor.com/background-agent?bcId=bc-96cd9ec1-5b9b-4dc0-8eb5-42685ffd47f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96cd9ec1-5b9b-4dc0-8eb5-42685ffd47f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

